### PR TITLE
feat: Overlay Loading 시작시 300ms 여유 시간 제공 #31

### DIFF
--- a/src/common/components/loading/OverlayLoading.tsx
+++ b/src/common/components/loading/OverlayLoading.tsx
@@ -1,9 +1,23 @@
+import React, { useState, useEffect } from "react";
 import { View, StyleSheet } from "react-native";
 import { ActivityIndicator } from "react-native-paper";
-import { color } from "../../styles/color";
-import { RFValue } from "react-native-responsive-fontsize";
 
 export default function OverlayLoading() {
+  const [isReadyToShow, setIsReadyToShow] = useState(false);
+
+  useEffect(() => {
+    const timerId = setTimeout(() => {
+      setIsReadyToShow(true);
+    }, 300); // 300ms
+
+    // 메모리 누수 방지
+    return () => clearTimeout(timerId);
+  }, []);
+
+  if (!isReadyToShow) {
+    return null;
+  }
+
   return (
     <View style={styles.overlayLoading}>
       <ActivityIndicator animating={true} size="large" />

--- a/src/domain/invitations/hooks/mutations/useInvitationMutations.ts
+++ b/src/domain/invitations/hooks/mutations/useInvitationMutations.ts
@@ -39,7 +39,7 @@ export const useUpdateInvitationStatusMutation = () => {
     },
     onSuccess: (data, variables) => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.invitations] });
-      Alert.alert("성공", data.message);
+      Alert.alert("초대 응답", data.message);
     },
   });
 };


### PR DESCRIPTION
- Loading 지연 시작으로 인해 화면의 깜박임을 최소화 하여 UX 경험 증진

<details>
<summary> PR 체크리스트</summary>
  
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?
- [ ] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

close #31 

## 변경사항

- OverlayLoading 컴포넌트가 `300ms` 뒤에 화면에 보이도록 설정합니다.
- 이로 인해 `API 응답 완료 메시지`와 `loading` 이 즉각적으로 UI에 표시될 경우에 발생하는 눈의 불편감을 줄일 수 있습니다.